### PR TITLE
Jednolitość pamięci w tablicy bloków.

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -1,4 +1,3 @@
-
 #include "chunk.h"
 
 Chunk::Chunk(Dimension* dimension, int x, int y, int z) {
@@ -14,20 +13,18 @@ Chunk::Chunk(Dimension* dimension, int x, int y, int z) {
     PyObject* chunkArray = PyObject_CallObject(generateChunkCallback, Py_BuildValue("(iiii)", x, y, z, chunkSize));
 
     // allocate memory
-    this->blocks = (Block***) malloc(chunkSize * sizeof(Block**));
+    this->blocks.reserve(chunkSize*chunkSize*chunkSize);
 
     for (int bX = 0; bX < chunkSize; bX++) {
-        this->blocks[bX] = (Block**) malloc(chunkSize * sizeof(Block*));
         PyObject* chunkArrayX = PyList_GetItem(chunkArray, bX);
 
         for (int bY = 0; bY < chunkSize; bY++) {
-            this->blocks[bX][bY] = (Block*) malloc(chunkSize * sizeof(Block));
             PyObject* chunkArrayXY = PyList_GetItem(chunkArrayX, bY);
 
             for (int bZ = 0; bZ < chunkSize; bZ++) {
                 PyObject* chunkBlock = PyList_GetItem(chunkArrayXY, bZ);
 
-                this->blocks[bX][bY][bZ] = Block(PyUnicode_AsUTF8(chunkBlock));
+                this->blocks[(bZ*(chunkSize*chunkSize))+(bY*chunkSize)+bX] = Block(PyUnicode_AsUTF8(chunkBlock));
             }
         }
     }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -16,6 +16,11 @@ private:
     Dimension* dimension;
     std::vector<Block> blocks;
 
+    inline Block& getBlock(int x, int y, int z) {
+        auto chunkSize = dimension->getChunkSize();
+        return this->blocks[(z * chunkSize * chunkSize) + (y * chunkSize) + x];
+    }
+
     int x, y, z;
 public:
     Chunk(Dimension* dimension, int x, int y, int z);

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -11,7 +11,7 @@ class Chunk;
 class Chunk {
 private:
     Dimension* dimension;
-    Block*** blocks;
+    Block* blocks;
 
     int x, y, z;
 public:

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -1,9 +1,12 @@
 #ifndef CHUNK_H
 #define CHUNK_H
 
+#include <vector>
+
 class Chunk;
 
 #include<Python.h>
+
 #include "block.h"
 
 #include "dimension.h"
@@ -11,7 +14,7 @@ class Chunk;
 class Chunk {
 private:
     Dimension* dimension;
-    Block* blocks;
+    std::vector<Block> blocks;
 
     int x, y, z;
 public:


### PR DESCRIPTION
Tablice poszarpane powodują spowolnienie wywołania kodu w związku z cache-miss'ami w CPU. Sposobem na uniknięcie tego problemu jest wykorzystanie tablic spłaszczonych/jednolitych.