### PR TITLE
Zamiana Wielkości, aby pasowały do nazw

### DIFF
--- a/src/py.cpp
+++ b/src/py.cpp
@@ -93,12 +93,12 @@ void initPython() {
 
     setClassDefaults(py_BlockClassType)
     py_BlockClassType.tp_name = "game.Block";
-    py_BlockClassType.tp_basicsize = sizeof(py_BlockInstanceClass);
+    py_BlockClassType.tp_basicsize = sizeof(py_BlockClass);
     py_BlockClassType.tp_init = reinterpret_cast<initproc>(pyInitBlock);
 
     setClassDefaults(py_BlockInstanceClassType)
     py_BlockInstanceClassType.tp_name = "game.BlockInstance";
-    py_BlockInstanceClassType.tp_basicsize = sizeof(py_BlockClass);
+    py_BlockInstanceClassType.tp_basicsize = sizeof(py_BlockInstanceClass);
     py_BlockInstanceClassType.tp_init = reinterpret_cast<initproc>(pyInitBlockInstance);
 
 


### PR DESCRIPTION
![Wielkość `py_BlockInstanceClass` jest przypisana klasie Block, a wielkość `py_BlockClass` klasie BlockInstance](https://github.com/user-attachments/assets/b80aae85-b7a6-481e-a5ee-9ba46a2a1db5)
Nie wiem czy to ma tak wyglądać. Jeśli jest to intencjonalne wywal ten PR.