### PR TITLE
Naprawa błędu segmentacji powiązanego z wielowątkowym wywołaniem funkcji pythona

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PROJECT_HEADER_FILES
     src/world.h
     src/entity.h
     src/hitbox.h
+    src/spinlock.h
 )
 
 set(PROJECT_PYTHON_FILES

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -2,8 +2,10 @@
 
 #include "block.h"
 #include "raylib.h"
+#include <mutex>
 
 std::vector<BlockTemplate*> blockList;
+std::mutex blockListLock{};
 
 BlockTemplate* findBlockTemplate(std::string name) {
     for (int i = 0; i < blockList.size(); i++) {
@@ -73,6 +75,7 @@ void unloadBlocks() {
 }
 
 int pyInitBlock(py_BlockClass* self, PyObject* args, PyObject* kwargs) {
+    std::lock_guard<std::mutex> lock{ blockListLock };
     char *name;
     int solid = 1;
     int visible = 1;

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -21,10 +21,10 @@ Chunk::Chunk(Dimension* dimension, ChunkPos x, ChunkPos y, ChunkPos z) {
     this->z = z;
 
     int chunkSize = dimension->getChunkSize();
-
+    
     PyObject* generateChunkCallback = dimension->getTemplate()->generateChunkCallback;
     PyObject* chunkArray = PyObject_CallObject(generateChunkCallback, Py_BuildValue("(iiii)", x, y, z, chunkSize));
-
+    
     // allocate memory
     this->blocks.reserve(chunkSize*chunkSize*chunkSize);
 

--- a/src/dimension.cpp
+++ b/src/dimension.cpp
@@ -3,8 +3,10 @@
 
 #include <stdexcept>
 #include <algorithm>
+#include <mutex>
 
 std::vector<DimensionTemplate*> dimensionList;
+std::mutex dimensionListMutex{};
 
 Dimension::Dimension(int type) {
     this->propeties = dimensionList[type];
@@ -132,6 +134,7 @@ Dimension * getDimensionInstance(py_DimensionClass self) {
 }
 
 int *py_defineDimension(py_DimensionClass * self, PyObject *args, PyObject *kwargs) {
+    std::lock_guard<std::mutex> lock{ dimensionListMutex };
     char *name;
     PyObject* generateChunkCallback = NULL;
     int chunkSize = 8;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,8 +8,10 @@
 #include "world.h"
 #include "states.h"
 #include "player.h"
+#include "spinlock.h"
 
 GameState gameState;
+extern spinlock lock;
 
 void exitGame() {
     unloadWorld();
@@ -26,13 +28,16 @@ int main() {
     //load data from python files
     defineGameData();
 
-    printf("Defined %d blocks.\n", getDefinedBlockCount());
+    printf("Defined %d blocks.\nLoading World...\n", getDefinedBlockCount());
 
     loadWorld();
 
     DisableCursor();
 
+    printf("Start\n");
+
     while (!WindowShouldClose()){
+        lock.unlock();
         BeginDrawing();
         ClearBackground(RAYWHITE);
 

--- a/src/py.cpp
+++ b/src/py.cpp
@@ -9,6 +9,7 @@
 #include "player.h"
 
 bool isPythonInitalized = false;
+PyThreadState* mainThreadState = NULL;
 
 
 static PyObject *py_setOnWorldLoadCallback(PyObject *self, PyObject *args, PyObject *kwargs) {
@@ -105,7 +106,8 @@ void initPython() {
     PyImport_AppendInittab("game", &PyInit_Game);
 
     Py_Initialize();
-
+    PyEval_InitThreads();   
+    mainThreadState = PyThreadState_Get();
     PyObject *obj = Py_BuildValue("s", "data/py/init.py");
     FILE* fp = _Py_fopen_obj(obj, "r+");;
     PyRun_SimpleFile(fp, "data/py/init.py");

--- a/src/spinlock.h
+++ b/src/spinlock.h
@@ -1,0 +1,42 @@
+#ifndef __SPINLOCK_H_
+#define __SPINLOCK_H_
+
+#include <atomic>
+#include <intrin.h>
+
+struct spinlock {
+    std::atomic<bool> lock_ = { 0 };
+
+    void lock() noexcept {
+        for (;;) {
+            // Optimistically assume the lock is free on the first try
+            if (!lock_.exchange(true, std::memory_order_acquire)) {
+                return;
+            }
+            // Wait for lock to be released without generating cache misses
+            while (lock_.load(std::memory_order_relaxed)) {
+                // Issue X86 PAUSE or ARM YIELD instruction to reduce contention between
+                // hyper-threads
+#ifdef _MSC_VER
+                _mm_pause();
+#else
+                __builtin_ia32_pause();
+#endif
+            }
+        }
+    }
+
+    bool try_lock() noexcept {
+        // First do a relaxed load to check if lock is free in order to prevent
+        // unnecessary cache misses if someone does while(!try_lock())
+        return !lock_.load(std::memory_order_relaxed) &&
+            !lock_.exchange(true, std::memory_order_acquire);
+    }
+
+    void unlock() noexcept {
+        lock_.store(false, std::memory_order_release);
+    }
+};
+
+
+#endif


### PR DESCRIPTION
Brakowało inicjacji wątków poprzez wywołanie `PyEval_InitThreads`
Utworzenie nowego stanu wątkowego dla wątku generacji świata.
Zastosowanie blokady obrotowej (spinlock).

Fixes skni-kod/kod-craft#5